### PR TITLE
Histogram update

### DIFF
--- a/q/exporter.q
+++ b/q/exporter.q
@@ -111,7 +111,7 @@ before:{[met;msg]
   .z.p}
 after:{[met;tmp;msg;res]
   .prom.updval[value`$"err_",met;-;1];
-  tm:(10e-9)*.z.p-tmp;
+  tm:(10e-10)*.z.p-tmp;
   .prom.updval[value`$"summ_",met;,;tm];
   .prom.updval[value`$"hist_",met;,;tm];}
 .prom.before_pg:before"sync"

--- a/q/extract.q
+++ b/q/extract.q
@@ -29,12 +29,14 @@ summary:{[d]
   hdr:", "sv/:labelhdr,/:(();()),enlist each"quantile=",/:wrapstring each string q;
   hdr:(("_sum";"_count"),count[q]#enlist""),'wraplabels each hdr;
   hdr,'" ",'string svals}
+
 histogram:{[d]
-  svals:raze(sum d`val;count d`val;deltas 1+asc[d`val]bin q:d`params);
+  svals:raze(sum d`val;count d`val;1+asc[d`val]bin q:asc d`params);
   labelhdr:$[count d`labelhdr;enlist d`labelhdr;()];
-  hdr:", "sv/:labelhdr,/:(();()),enlist each"le=",/:wrapstring each string q;
-  hdr:(("_sum";"_count"),count[q]#enlist""),'wraplabels each hdr;
-  hdr,'" ",'string svals}
+  hdr:", "sv/:labelhdr,/:(();()),enlist each"le=",/:wrapstring each string[q],enlist "+Inf";
+  hdr:(("_sum";"_count"),(1+count[q])#enlist""),'wraplabels each hdr;
+  hdr,'" ",'string svals,svals[1]
+ };
 
 // extract metric info
 extractall:{[]


### PR DESCRIPTION
Summary and histogram metrics are set to `_seconds`

Change to `after:{}` to return seconds
```
q)tm1:`timestamp$.z.d
q)tm2:tm1+0D00:00:05
q)
q)(10e-9)*tm2-tm1
50f
q)(10e-10)*tm2-tm1
5f
q)
```

Prometheus histogram buckets are required to be cumulative, with the last bucket matching the value of `_count`

Additionally a `+Inf` `le` is required.

Without the above changes the PromQL queries fail, returning `NaN`
```
histogram_quantile(0.9, rate(kdb_sync_histogram_seconds{service="kx-tp"}[10s]) )
```

Without changes
```
{container="tp-metrics", endpoint="metrics", instance="10.0.1.22:8080", job="kx-tp", namespace="kx", pod="kx-tp-566978d9fc-g4z4r", service="kx-tp"}

NaN
```

With changes
```
{container="tp-metrics", endpoint="metrics", instance="10.0.0.39:8080", job="kx-tp", namespace="kx", pod="kx-tp-688fbf59cc-9l9v5", service="kx-tp"}

0.225
```