### PR TITLE
Removed depreciated/unused builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 matrix:
   include:
-  - dist: xenial
-    os: linux
-  - dist: trusty 
-    os: linux
-  - dist: bionic
+  - dist: focal
     os: linux
   - os: osx
   - os: windows
@@ -94,5 +90,5 @@ deploy:
   file: "$FILE_NAME"
   on:
     tags: true
-    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = trusty && $TRAVIS_OS_NAME = linux) 
+    condition: $TRAVIS_OS_NAME = windows || $TRAVIS_OS_NAME = osx || ($TRAVIS_DIST = focal && $TRAVIS_OS_NAME = linux) 
   skip_cleanup: 'true'


### PR DESCRIPTION
Not building, so dont need to run on various linux machines.
Trusty is depreciated ( https://docs.travis-ci.com/user/enterprise/trusty/ )
Should speed up the checks/release.