### PR TITLE
fix(extract): return websocket handler result

### DIFF
--- a/q/extract.q
+++ b/q/extract.q
@@ -89,7 +89,7 @@ ph:{[f;msg]$["metrics"~msg 0;
   [tmp:before_ph msg;res:f msg;after_ph[tmp;msg;res];res]
  ]}
 pp:{[f;msg]tmp:before_pp msg;res:f msg;after_pp[tmp;msg;res];res}
-ws:{[f;msg]tmp:before_ws msg;res:f msg;after_ws[tmp;msg;res];}
+ws:{[f;msg]tmp:before_ws msg;res:f msg;after_ws[tmp;msg;res];res}
 ts:{[f;dtm]tmp:before_ts dtm;res:f dtm;after_ts[tmp;dtm;res];}
 
 // overload existing event handlers


### PR DESCRIPTION
The `ws` handler was missing `;res` at the end, unlike all other handlers (`pg`, `ph`, `pp`) which return the result. This caused websocket calls to return null/nothing to the caller.