### PR TITLE
fix(install): guard shared-lib directory check behind lib/ existence

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,9 +54,11 @@ if [ ! -w "$Q_SCRIPT_DIR" ]; then
     echo "ERROR: Directory '$Q_SCRIPT_DIR' does not exist"
     exit 1
 fi
-if [ ! -w "$Q_SHARED_LIB_DIR" ]; then
+if [ -d lib ]; then
+  if [ ! -d "$Q_SHARED_LIB_DIR" ]; then
     echo "ERROR: Directory '$Q_SHARED_LIB_DIR' does not exist"
     exit 1
+  fi
 fi
 
 if [ -d q ]; then


### PR DESCRIPTION
The install script checked `Q_SHARED_LIB_DIR` existence unconditionally. When there is no `lib/` directory (e.g. on Linux), the script would fail even though no shared libraries need to be installed. Fixed by guarding the check behind `[ -d lib ]`.