### PR TITLE
fix(install): remove self-referencing shared lib path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ else
 fi
 
 Q_SCRIPT_DIR=${QHOME}${Q_PATH_SEP}
-Q_SHARED_LIB_DIR="${QHOME}${Q_PATH_SEP}${Q_HOST_TYPE}${Q_SHARED_LIB_DIR}${Q_MACH_TYPE}${Q_PATH_SEP}"
+Q_SHARED_LIB_DIR="${QHOME}${Q_PATH_SEP}${Q_HOST_TYPE}${Q_MACH_TYPE}${Q_PATH_SEP}"
 
 # check destination directory exists
 if [ ! -w "$Q_SCRIPT_DIR" ]; then


### PR DESCRIPTION
Fix Q_SHARED_LIB_DIR construction so it does not accidentally include an inherited Q_SHARED_LIB_DIR environment value. The destination path should be derived only from QHOME, host type, machine type, and path separator.