### PR TITLE
fix(install): quote install.bat paths and detect architecture

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,19 +1,23 @@
 @echo off
 
 IF "%QHOME%"=="" (
-    ECHO ERROR: Enviroment variable QHOME is NOT defined 
-    EXIT /B
+    ECHO ERROR: Environment variable QHOME is NOT defined
+    EXIT /B 1
 )
 
-IF NOT EXIST %QHOME%\w64 (
-    ECHO ERROR: Installation destination %QHOME%\w64 does not exist
-    EXIT /B
+REM Detect architecture: prefer w64, fall back to w32
+IF EXIST "%QHOME%\w64" (
+    SET Q_ARCH_DIR=w64
+) ELSE IF EXIST "%QHOME%\w32" (
+    SET Q_ARCH_DIR=w32
+) ELSE (
+    ECHO ERROR: Neither %QHOME%\w64 nor %QHOME%\w32 found
+    EXIT /B 1
 )
-
 
 IF EXIST q (
     ECHO Copying q script to %QHOME%
-    COPY q\* %QHOME%
+    COPY q\* "%QHOME%"
     IF %ERRORLEVEL% NEQ 0 (
         ECHO ERROR: Copy failed
         EXIT /B %ERRORLEVEL%
@@ -21,8 +25,8 @@ IF EXIST q (
 )
 
 IF EXIST lib (
-    ECHO Copying DLL to %QHOME%\w64
-    COPY lib\* %QHOME%\w64\
+    ECHO Copying DLL to %QHOME%\%Q_ARCH_DIR%
+    COPY lib\* "%QHOME%\%Q_ARCH_DIR%\"
     IF %ERRORLEVEL% NEQ 0 (
         ECHO ERROR: Copy failed
         EXIT /B %ERRORLEVEL%
@@ -30,3 +34,4 @@ IF EXIST lib (
 )
 
 ECHO Installation complete
+EXIT /B 0


### PR DESCRIPTION
Harden install.bat by quoting QHOME-derived paths, returning non-zero status for fatal preflight failures, and using PROCESSOR_ARCHITECTURE to select the q machine type.