### PR TITLE
fix(ci): use supported GitHub Actions runner label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     if: ${{ github.repository == 'KxSystems/prometheus-kdb-exporter' }}
     name: Build
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out code
@@ -36,7 +36,7 @@ jobs:
   release:
     name: Upload release assets
     if: github.event_name == 'release'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: write


### PR DESCRIPTION
Update the workflow runner label to a supported GitHub Actions image label so CI jobs can be scheduled.