### PR TITLE
fix(docker): support host.docker.internal on Linux

### DIFF
--- a/examples/DockerCompose/docker-compose-linux.yml
+++ b/examples/DockerCompose/docker-compose-linux.yml
@@ -3,6 +3,8 @@ version: '3.7'
 services:
     prometheus:
         image: prom/prometheus:v2.15.1
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
         volumes:
             - ./prometheus-linux.yml:/etc/prometheus/prometheus.yml
         ports:

--- a/examples/DockerCompose/docker-compose.yml
+++ b/examples/DockerCompose/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
     prometheus:
         image: prom/prometheus:v2.15.1
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
         volumes:
             - ./prometheus.yml:/etc/prometheus/prometheus.yml
         ports:


### PR DESCRIPTION
Add host-gateway mapping for host.docker.internal in the Docker Compose examples so Linux Docker users can reach services running on the host.